### PR TITLE
Add semantic_version as an explicit requirement for installation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -48,20 +48,6 @@ Download / install the app using pip:
 
     pip install django-package-monitor
 
-NB This package relies on `semantic_version` which has a bug in its PyPI
-distributed version (2.4.2). We have submitted a patch for this bug
-(https://github.com/rbarrois/python-semanticversion/pull/34), but until this
-is merged and a new release made, you need to install this package
-independently.
-
-You should therefore list add it to your requirements:
-
-.. code:: shell
-
-    # requirements.txt
-    -e git+https://github.com/yunojuno/python-semanticversion.git@e8a1b3a543ab7d8b303f54e3ce48681f6c1589e7#egg=semantic_version-dev
-    django-package-monitor
-
 Add the app ``package_monitor`` to your ``INSTALLED_APPS`` Django setting:
 
 .. code:: python

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setup(
     ],
     install_requires=[
         'requirements-parser>=0.1.0',
+        'semantic_version>=2.5.0',
     ],
     include_package_data=True,
     description='Requirements package monitor for Django projects.',


### PR DESCRIPTION
Previously, a specific, commit-pinned, bugfix version of semantic_version was required to make django-package-monitor work.

That bug has now been fixed in `semantic_version==2.5.0`, so this commit adds the official 2.5.0 release as a dependency of django-package-monitor, as separately installing the pinned version is no longer the best approach. 

