### PR TITLE
Fix issue #8 - null license value from PyPI

### DIFF
--- a/package_monitor/pypi.py
+++ b/package_monitor/pypi.py
@@ -84,7 +84,7 @@ class Package(object):
         return self.data().get('info')
 
     def licence(self):
-        return self.info().get('license', '(unspecified)')
+        return self.info().get('license') or '(unspecified)'
 
     def latest_version(self):
         return parse_version(self.info().get('version'))


### PR DESCRIPTION
If the license value in the PyPI JSON is null, the previous
implementation would parse that as None, and attempt to load that into
the database, which would fail.

See https://github.com/yunojuno/django-package-monitor/issues/8