### PR TITLE
Make migrations python3 friendly

### DIFF
--- a/package_monitor/migrations/0001_initial.py
+++ b/package_monitor/migrations/0001_initial.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-
+from __future__ import unicode_literals
 
 from django.db import migrations, models
 import semantic_version.django_fields
@@ -15,15 +15,15 @@ class Migration(migrations.Migration):
             name='PackageVersion',
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
-                ('raw', models.CharField(help_text=b'The line specified in the requirements file.', max_length=200)),
-                ('package_name', models.CharField(help_text=b'The name of the package on PyPI.', unique=True, max_length=100)),
-                ('current_version', semantic_version.django_fields.VersionField(help_text=b'The current version as specified in the requirements file. ', max_length=200, null=True, blank=True)),
-                ('latest_version', semantic_version.django_fields.VersionField(help_text=b'Latest version available from PyPI.', max_length=200, null=True, blank=True)),
-                ('licence', models.CharField(help_text=b'The licence used (extracted from PyPI info).', max_length=100, blank=True)),
-                ('diff_status', models.CharField(default=b'unknown', help_text=b'The diff between current and latest versions. Updated via update_latest_version.', max_length=10, choices=[(b'unknown', b'Unknown'), (b'none', b'Up-to-date'), (b'major', b'Major'), (b'minor', b'Minor'), (b'patch', b'Patch'), (b'other', b'Other')])),
-                ('checked_pypi_at', models.DateTimeField(help_text=b'When PyPI was last checked for this package.', null=True, blank=True)),
-                ('is_editable', models.BooleanField(default=False, help_text=b"True if this requirement is specified with '-e' flag.")),
-                ('url', models.URLField(help_text=b'The URL to check - PyPI or repo (if editable).', null=True, blank=True)),
+                ('raw', models.CharField(help_text='The line specified in the requirements file.', max_length=200)),
+                ('package_name', models.CharField(help_text='The name of the package on PyPI.', unique=True, max_length=100)),
+                ('current_version', semantic_version.django_fields.VersionField(help_text='The current version as specified in the requirements file. ', max_length=200, null=True, blank=True)),
+                ('latest_version', semantic_version.django_fields.VersionField(help_text='Latest version available from PyPI.', max_length=200, null=True, blank=True)),
+                ('licence', models.CharField(help_text='The licence used (extracted from PyPI info).', max_length=100, blank=True)),
+                ('diff_status', models.CharField(default='unknown', help_text='The diff between current and latest versions. Updated via update_latest_version.', max_length=10, choices=[('unknown', 'Unknown'), ('none', 'Up-to-date'), ('major', 'Major'), ('minor', 'Minor'), ('patch', 'Patch'), ('other', 'Other')])),
+                ('checked_pypi_at', models.DateTimeField(help_text='When PyPI was last checked for this package.', null=True, blank=True)),
+                ('is_editable', models.BooleanField(default=False, help_text="True if this requirement is specified with '-e' flag.")),
+                ('url', models.URLField(help_text='The URL to check - PyPI or repo (if editable).', null=True, blank=True)),
             ],
         ),
     ]

--- a/package_monitor/migrations/0002_auto_20151126_1453.py
+++ b/package_monitor/migrations/0002_auto_20151126_1453.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-
+from __future__ import unicode_literals
 
 from django.db import migrations, models
 

--- a/package_monitor/migrations/0003_packageversion_next_version.py
+++ b/package_monitor/migrations/0003_packageversion_next_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-
+from __future__ import unicode_literals
 
 from django.db import migrations, models
 import semantic_version.django_fields
@@ -15,6 +15,6 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='packageversion',
             name='next_version',
-            field=semantic_version.django_fields.VersionField(help_text=b'Next available version available from PyPI.', max_length=200, null=True, blank=True),
+            field=semantic_version.django_fields.VersionField(help_text='Next available version available from PyPI.', max_length=200, null=True, blank=True),
         ),
     ]

--- a/package_monitor/migrations/0004_auto_20160109_1339.py
+++ b/package_monitor/migrations/0004_auto_20160109_1339.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-
+from __future__ import unicode_literals
 
 from django.db import migrations, models
 
@@ -14,11 +14,11 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='packageversion',
             name='is_editable',
-            field=models.BooleanField(default=False, help_text=b"True if this requirement is specified with '-e' flag.", verbose_name=b'Editable (-e)'),
+            field=models.BooleanField(default=False, help_text="True if this requirement is specified with '-e' flag.", verbose_name='Editable (-e)'),
         ),
         migrations.AlterField(
             model_name='packageversion',
             name='url',
-            field=models.URLField(help_text=b'The PyPI URL to check - (blank if editable).', null=True, blank=True),
+            field=models.URLField(help_text='The PyPI URL to check - (blank if editable).', null=True, blank=True),
         ),
     ]

--- a/package_monitor/migrations/0005_packageversion_is_parseable.py
+++ b/package_monitor/migrations/0005_packageversion_is_parseable.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-
+from __future__ import unicode_literals
 
 from django.db import migrations, models
 
@@ -14,6 +14,6 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='packageversion',
             name='is_parseable',
-            field=models.BooleanField(default=False, help_text=b'True if the version can be parsed as a valid semver version.', verbose_name=b'Parseable'),
+            field=models.BooleanField(default=False, help_text='True if the version can be parsed as a valid semver version.', verbose_name='Parseable'),
         ),
     ]

--- a/package_monitor/migrations/0006_add_python_version_info.py
+++ b/package_monitor/migrations/0006_add_python_version_info.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-
+from __future__ import unicode_literals
 
 from django.db import migrations, models
 
@@ -14,12 +14,12 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='packageversion',
             name='python_support',
-            field=models.CharField(default='', help_text=b'Python version support as specified in the PyPI classifiers.', max_length=100),
+            field=models.CharField(default='', help_text='Python version support as specified in the PyPI classifiers.', max_length=100),
             preserve_default=False,
         ),
         migrations.AddField(
             model_name='packageversion',
             name='supports_py3',
-            field=models.NullBooleanField(default=None, help_text=b'Does this package support Python3?'),
+            field=models.NullBooleanField(default=None, help_text='Does this package support Python3?'),
         ),
     ]

--- a/package_monitor/migrations/0007_add_django_version_info.py
+++ b/package_monitor/migrations/0007_add_django_version_info.py
@@ -14,11 +14,11 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='packageversion',
             name='django_support',
-            field=models.CharField(help_text=b'Django version support as specified in the PyPI classifiers.', max_length=100, null=True, blank=True),
+            field=models.CharField(help_text='Django version support as specified in the PyPI classifiers.', max_length=100, null=True, blank=True),
         ),
         migrations.AlterField(
             model_name='packageversion',
             name='python_support',
-            field=models.CharField(help_text=b'Python version support as specified in the PyPI classifiers.', max_length=100, null=True, blank=True),
+            field=models.CharField(help_text='Python version support as specified in the PyPI classifiers.', max_length=100, null=True, blank=True),
         ),
     ]

--- a/package_monitor/models.py
+++ b/package_monitor/models.py
@@ -1,5 +1,7 @@
 # *-8 coding: utf-8 -*-
 """Parse requirements file, and work out whether there are any updates."""
+from __future__ import unicode_literals
+
 import logging
 
 from django.db import models

--- a/package_monitor/tests/test_migrations.py
+++ b/package_monitor/tests/test_migrations.py
@@ -1,0 +1,24 @@
+from __future__ import unicode_literals
+
+from django.apps import apps
+from django.db import connection
+from django.db.migrations.autodetector import MigrationAutodetector
+from django.db.migrations.executor import MigrationExecutor
+from django.db.migrations.state import ProjectState
+from django.test import TestCase
+
+
+class MigrationsTests(TestCase):
+
+    def test_for_missing_migrations(self):
+        """Checks if there're models changes which aren't reflected in migrations."""
+        migrations_loader = MigrationExecutor(connection).loader
+        migrations_detector = MigrationAutodetector(
+            from_state=migrations_loader.project_state(),
+            to_state=ProjectState.from_apps(apps)
+        )
+        if migrations_detector.changes(graph=migrations_loader.graph):
+            self.fail(
+                'Your models have changes that are not yet reflected '
+                'in a migration. You should add them now.'
+            )


### PR DESCRIPTION
Under python3 `makemigrations` complains that `package_monitor` has
changes in models which are not reflected in its migrations.

It's caused by b'' strings.